### PR TITLE
npm: add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:integration": "./test/mocha-run-suite.sh 'test/integration/**/*.ts'",
     "prepublishOnly": "npm run build"
   },
+  "main": "lib/index.js",
   "bin": {
     "protoc-gen-ts": "bin/protoc-gen-ts"
   },


### PR DESCRIPTION
pnpm (at least as-of 8.6) assumes it needs to build a dependency if it has a `prepublishOnly` script and if the file in package.json's `main` field (or `./index.js` as a fallback) doesn't exist in the published `.tgz` file [1]. Since the `generate-promises-build` branch is already built and includes committed versions of compiled files, add a `main` field to `package.json` to avoid rebuilding this package when installed via pnpm.

[1] https://github.com/pnpm/pnpm/blob/f0af6b02cf84a726449762b830abe71416df42a8/exec/prepare-package/src/index.ts#L61-L62